### PR TITLE
Kogge-Stone adder

### DIFF
--- a/Chip.java
+++ b/Chip.java
@@ -4616,6 +4616,7 @@ Step  p
        Bits      o = c.outputBits("o", a.sum());
        c.Output    ("co", a.carry);
        c.simulate  ();
+       a.sum  .ok(i+j);
        System.err.println("B="+B+" i="+i+" j="+j+" sum="+o.Int()+" steps="+c.steps);
    }
 
@@ -5396,7 +5397,8 @@ Step  o     e
 
   static void newTests()                                                        // Tests being worked on
    {oldTests();
-    test_binary_add();
+    //test_binary_add();
+    test_binary_add_kogge_stone();
    }
 
   public static void main(String[] args)                                        // Test if called as a program

--- a/Chip.java
+++ b/Chip.java
@@ -1981,7 +1981,7 @@ public class Chip                                                               
     final Bits G = andBits(n(output, "G"), in1, in2);                          // Generate prefix bits
     final Bits P = xorBits(n(output, "P"), in1, in2);                          // Propagate prefix bits
     final Bits G_next = bits(n(output, "G_next"), B);                                          // Result bits
-    final Bits P_next = bits(n(output, "G_next"), B);                                          // Result bits
+    final Bits P_next = bits(n(output, "P_next"), B);                                          // Result bits
     //final String R = n(output, "result"), K = n(output, "carry");
     int step = 1;
     while (step < B) {

--- a/Chip.java
+++ b/Chip.java
@@ -4613,6 +4613,7 @@ Step  p
           Bits      I = c.bits("i", B, i);
           Bits      J = c.bits("j", B, j);
           BinaryAdd a = c.binaryAddKoggeStone("ij",  I, J);
+          c.outputBits("o", a.sum());
           c.Output    ("co", a.carry);
           c.simulate  ();
           a.sum  .ok((i+j) %  B2);

--- a/Chip.java
+++ b/Chip.java
@@ -1971,18 +1971,17 @@ public class Chip                                                               
    {return binaryAdd(output, in1, bits(n(output, "constant"), in1.bits(), in2));
    }
 
-   // Kogge-Stone O(log(n)) adder
+                                                                                // Kogge-Stone O(log(n)) adder
    BinaryAdd binaryAddKoggeStone(String output, Bits in1, Bits in2)             // Add two bit buses of the same size to make a bit bus one bit wider
    {final int b = in1.bits();                                                   // Number of bits in input monotone mask
     final int B = in2.bits();                                                   // Number of bits in input monotone mask
     if (b != B) stop("Input bit buses must have the same size, not", b, B);     // Check sizes match
-    final Bits o = bits(output, b);                                          // Result bits
-    final Bits p = xorBits (n(output, "p"), in1, in2);                       // Propagate bits
-    final Bits G = andBits(n(output, "G"), in1, in2);                          // Generate prefix bits
-    final Bits P = xorBits(n(output, "P"), in1, in2);                          // Propagate prefix bits
-    final Bits G_next = bits(n(output, "G_next"), B);                                          // Result bits
-    final Bits P_next = bits(n(output, "P_next"), B);                                          // Result bits
-    //final String R = n(output, "result"), K = n(output, "carry");
+    final Bits o = bits(output, b);                                             // Result bits
+    final Bits p = xorBits (n(output, "p"), in1, in2);                          // Propagate bits
+    final Bits G = andBits(n(output, "G"), in1, in2);                           // Generate prefix bits
+    final Bits P = xorBits(n(output, "P"), in1, in2);                           // Propagate prefix bits
+    final Bits G_next = bits(n(output, "G_next"), B);                           // Result bits
+    final Bits P_next = bits(n(output, "P_next"), B);                           // Result bits
     int step = 1;
     while (step < B) {
         for (int i = step; i < B; i++) {
@@ -1997,9 +1996,9 @@ public class Chip                                                               
         }
         step *= 2;
     }
-    // Calculate carries
-    final Bits c = bits   (n(output, "carry"),     B+1);                          // Carry bits
-    Zero(c.b(1));                                                             // First carry is always zero
+                                                                               // Calculate carries
+    final Bits c = bits   (n(output, "carry"),     B+1);                       // Carry bits
+    Zero(c.b(1));                                                              // First carry is always zero
     for (int i = 2; i <= (B+1); i++) {
         Gate ci = And(n(i, output, "ci"), P.b(i-1), c.b(i-1));
         Or(c.b(i), G.b(i-1), ci);
@@ -2009,10 +2008,8 @@ public class Chip                                                               
         Gate ri = Xor(n(i, output, "ri"), p.b(i), c.b(i));
         Or(o.b(i), ri, G.b(i));
     }
-    return new BinaryAdd(c.b(B+1), o);                                            // Carry out of the highest bit, result
+    return new BinaryAdd(c.b(B+1), o);                                          // Carry out of the highest bit, result
    }
-
-
 
   Bits binaryTwosComplement(String output, Bits in)                             // Form the binary twos complement of a number
    {final int         B = in.bits();                                            // Number of bits


### PR DESCRIPTION
Preliminary version. Currently, the test case gives error:

```
Gate name: ij_G_2 type Or driven by too many other gates, including one from gate: ij_z_1_1
  Chip.java:0394:compileGate
  Chip.java:0632:compileChip
  Chip.java:0751:simulate
  Chip.java:0748:simulate
  Chip.java:4496:test_binary_kogge_stone
  Chip.java:5286:oldTests
  Chip.java:5325:newTests
  Chip.java:5331:main
```
